### PR TITLE
FIX: Update topic-list-item override

### DIFF
--- a/common/header.html
+++ b/common/header.html
@@ -1,9 +1,9 @@
 <div class="background-container"></div>
 
-<script>
-  var TopicListComponent = require('discourse/components/topic-list').default;
-  TopicListComponent.reopen({
+<script type="text/discourse-plugin" version="0.8">
+  api.modifyClass("component:topic-list", {
     showLikes: true
+    pluginId: "mot-graceful"
   });
 </script>
 


### PR DESCRIPTION
This commit updates the override to use a proper discourse plugin initializer, rather than a raw script tag. This should resolve boot-order-related issues.